### PR TITLE
fix: prefix /supakit endpoints with app base path

### DIFF
--- a/src/lib/browser/storage.ts
+++ b/src/lib/browser/storage.ts
@@ -2,6 +2,7 @@ import type { SupportedStorage } from '@supabase/supabase-js'
 import { getCookieOptions } from '../config/index.js'
 import { browser, isAuthToken } from '../utils.js'
 import { serialize } from 'cookie'
+import { base } from '$app/paths'
 
 let token = ''
 let name = ''
@@ -25,7 +26,7 @@ export const CookieStorage: SupportedStorage = {
 
     const getCookie = async () => {
       try {
-        const res = await fetch('/supakit', {
+        const res = await fetch(`${base}/supakit`, {
           method: 'GET',
           headers: {
             'x-csrf-token': csrf.token,
@@ -67,7 +68,7 @@ export const CookieStorage: SupportedStorage = {
       })
 
       try {
-        const res = await fetch('/supakitCSRF', {
+        const res = await fetch(`${base}/supakitCSRF`, {
           method: 'POST',
           body: JSON.stringify(csrf)
         })
@@ -88,7 +89,7 @@ export const CookieStorage: SupportedStorage = {
     if (isAuthToken(key)) cached_session = JSON.parse(value)
     const csrf = getCSRF()
     try {
-      const res = await fetch('/supakit', {
+      const res = await fetch(`${base}/supakit`, {
         method: 'POST',
         body: JSON.stringify({ key, value }),
         headers: {
@@ -107,7 +108,7 @@ export const CookieStorage: SupportedStorage = {
     if (isAuthToken(key)) cached_session = null
     const csrf = getCSRF()
     try {
-      const res = await fetch('/supakit', {
+      const res = await fetch(`${base}/supakit`, {
         method: 'DELETE',
         body: JSON.stringify({ key }),
         headers: {

--- a/src/lib/server/cookies.ts
+++ b/src/lib/server/cookies.ts
@@ -1,12 +1,13 @@
 import { getCookieOptions } from '../config/index.js'
 import { json, type Handle } from "@sveltejs/kit"
 import { csrf_check, isAuthToken } from '../utils.js'
+import { base } from '$app/paths'
 
 export const cookies = (async ({ event, resolve }) => {
   const { url, request, cookies } = event
   const cookie_options = getCookieOptions()
 
-  if (url.pathname === '/supakitCSRF') {
+  if (url.pathname === `${base}/supakitCSRF`) {
     const forbidden = csrf_check(event)
     if (forbidden) return forbidden
 
@@ -27,7 +28,7 @@ export const cookies = (async ({ event, resolve }) => {
   }
   
   /* Handle request to Supakit's cookie route */
-  if (url.pathname === '/supakit') {
+  if (url.pathname === `${base}/supakit`) {
     const forbidden = csrf_check(event)
     if (forbidden) return forbidden
 


### PR DESCRIPTION
The `/supakit` and `/supakitCSRF` endpoints don't currently work with a custom `kit.paths.base`. This PR fixes that :).