### PR TITLE
feat: add debug auth option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "supakit",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "svelte-kit sync && svelte-package",

--- a/src/lib/browser/storage.ts
+++ b/src/lib/browser/storage.ts
@@ -1,5 +1,5 @@
 import type { SupportedStorage } from '@supabase/supabase-js'
-import { isBrowser, isAuthToken } from '../utils.js'
+import { browserEnv, isAuthToken } from '../utils.js'
 import { base } from '$app/paths'
 
 let token = ''
@@ -21,7 +21,7 @@ const csrf_route = `${base}/supakit/csrf`
 
 export const CookieStorage: SupportedStorage = {
   async getItem(key) {
-    if (!isBrowser()) return null
+    if (!browserEnv()) return null
     if (isAuthToken(key) && cached_session) return cached_session
     let csrf = getCsrf()
 
@@ -73,7 +73,7 @@ export const CookieStorage: SupportedStorage = {
     }
   },
   async setItem(key, value) {
-    if (!isBrowser()) return
+    if (!browserEnv()) return
     if (isAuthToken(key)) cached_session = JSON.parse(value)
     const csrf = getCsrf()
     try {
@@ -92,7 +92,7 @@ export const CookieStorage: SupportedStorage = {
     }
   },
   async removeItem(key) {
-    if (!isBrowser()) return
+    if (!browserEnv()) return
     if (isAuthToken(key)) cached_session = null
     const csrf = getCsrf()
     try {

--- a/src/lib/server/endpoints.ts
+++ b/src/lib/server/endpoints.ts
@@ -21,9 +21,9 @@ export const endpoints = (async ({ event, resolve }) => {
       auth: {
         autoRefreshToken: false,
         detectSessionInUrl: false,
-        ...(cookie_options?.name ? { storageKey: cookie_options.name } : {}),
         storage: new CookieStorage({ cookies, cookie_options }),
-        flowType: 'pkce'
+        flowType: 'pkce',
+        ...(cookie_options?.name ? { storageKey: cookie_options.name } : {})
       }
     })
 

--- a/src/lib/server/locals.ts
+++ b/src/lib/server/locals.ts
@@ -33,9 +33,10 @@ export const locals = (async ({ event, resolve }) => {
     auth: {
       autoRefreshToken: false,
       detectSessionInUrl: false,
-      ...(cookie_options?.name ? { storageKey: cookie_options.name } : {}),
+      persistSession: true,
       storage: new CookieStorage({ cookies, cookie_options }),
       flowType: client_options?.auth?.flowType ?? 'pkce',
+      ...(cookie_options?.name ? { storageKey: cookie_options.name } : {})
     }
   })
 

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -10,7 +10,8 @@ export type SupabaseClientOptionsWithLimitedAuth<SchemaName = 'public'> = Omit<
 	'auth'
 > & {
   auth?: {
-    flowType: AuthFlowType
+    flowType?: AuthFlowType
+    debug?: boolean
   }
 }
 export type StateChangeCallback = ({ event, session }: { event: AuthChangeEvent, session: Session | null }) => Promise<type> | void

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,7 +2,7 @@ import type { GenericObjectOptions } from './types/index.js'
 import { getSupabaseLoadClientCookieOptions } from './config/index.js'
 import { error, json, text, type RequestEvent } from '@sveltejs/kit'
 
-export const isBrowser = () => typeof document !== 'undefined'
+export const browserEnv = () => typeof document !== 'undefined'
 
 export const isAuthToken = (name: string) => {
   const regex = /^sb-.*-auth-token$/


### PR DESCRIPTION
If you'd like to debug auth, pass this boolean as `true`
into your client options and you'll get verbose output
during auth operations.
