### PR TITLE
breaking: fix client storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Create a Supabase client in your root +layout.ts file. We're using `$env/dynamic
 
 This client will now be available in either `data` or `$page.data` in your downstream load functions and pages.
 
-Pass in an object of [Supabase Client Options](https://supabase.com/docs/reference/javascript/initializing) as the third parameter to `createSupabaseLoadClient`. Any options you pass in here, you'll want to setup for the [server client](#server-side-client-and-options) as well.
+Pass in an object of [Supabase Client Options](https://supabase.com/docs/reference/javascript/initializing) as the fourth parameter to `createSupabaseLoadClient`. Any options you pass in here, you'll want to setup for the [server client](#server-side-client-and-options) as well.
 
 Since Supakit only allows certain auth options, we've included them below. Type defaults are shown as the last option.
 
@@ -121,7 +121,8 @@ export const load = async ({ data: { session }, depends }) => {
 
   const supabase = createSupabaseLoadClient<Database>(
     env.PUBLIC_SUPABASE_URL, 
-    env.PUBLIC_SUPABASE_ANON_KEY
+    env.PUBLIC_SUPABASE_ANON_KEY,
+    session
   )
 
   return { supabase, session }
@@ -307,7 +308,8 @@ import type { Database } from '$lib/database.d'
 export const load = async ({ data: { session } }) => {
   const supabase = createSupabaseLoadClient<Database>(
     env.PUBLIC_SUPABASE_URL, 
-    env.PUBLIC_SUPABASE_ANON_KEY, {
+    env.PUBLIC_SUPABASE_ANON_KEY, 
+    session, {
       auth: {
         flowType: 'implicit'
       }
@@ -437,7 +439,7 @@ Because Supakit uses secure httpOnly cookie storage: setting, getting, and delet
 #### Cookie Options
 You can set your own options by passing in an object of `SecureCookieOptions` plus `name` for a custom cookie storage key. Whatever you pass in will be merged with the defaults - overriding when appropriate. Cookie options should be the same for the Load client and Server client.
 
-This is the fourth parameter for `createSupabaseLoadClient`.
+This is the fifth parameter for `createSupabaseLoadClient`.
 
 Type:
 ```ts
@@ -463,7 +465,8 @@ export const load = async ({ data: { session } }) => {
   const supabase = createSupabaseLoadClient<Database>(
     env.PUBLIC_SUPABASE_URL, 
     env.PUBLIC_SUPABASE_ANON_KEY,
-    {}, /* Supabase client options is the third parameter */
+    session,
+    {}, /* Supabase client options is the fourth parameter */
     {
       maxAge: 60 * 60 * 24 * 365 * 100,
       sameSite: 'strict',
@@ -549,6 +552,7 @@ export const load = async ({ data: { session } }) => {
   const supabase = createSupabaseLoadClient<Database>(
     env.PUBLIC_SUPABASE_URL, 
     env.PUBLIC_SUPABASE_ANON_KEY,
+    session,
     {
       auth: {
         debug: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "supakit",
-	"version": "1.4.2",
+	"version": "1.5.0",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "svelte-kit sync && svelte-package",

--- a/src/lib/browser/client.ts
+++ b/src/lib/browser/client.ts
@@ -1,4 +1,4 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+import { createClient, type Session, type SupabaseClient } from '@supabase/supabase-js'
 import { CookieStorage } from './storage.js'
 import { setSupabaseLoadClientCookieOptions } from '../config/index.js'
 import type { SupabaseClientOptionsWithLimitedAuth, SecureCookieOptionsPlusName, GenericSchema } from '../types/index.js'
@@ -18,6 +18,7 @@ export const createSupabaseLoadClient = <
 >(
   supabase_url: string,
   supabase_key: string,
+  session: Session | null,
   options?: SupabaseClientOptionsWithLimitedAuth<SchemaName>,
   cookie_options?: SecureCookieOptionsPlusName
 ): SupabaseClient<Database, SchemaName, Schema> => {
@@ -32,7 +33,7 @@ export const createSupabaseLoadClient = <
       autoRefreshToken: browser_env,
       detectSessionInUrl: browser_env,
       persistSession: true,
-      storage: CookieStorage,
+      storage: new CookieStorage(session),
       flowType: options?.auth?.flowType ?? 'pkce',
       debug: options?.auth?.debug ?? false,
       ...(cookie_options?.name ? { storageKey: cookie_options.name } : {})

--- a/src/lib/browser/storage.ts
+++ b/src/lib/browser/storage.ts
@@ -1,4 +1,4 @@
-import type { SupportedStorage } from '@supabase/supabase-js'
+import type { Session, SupportedStorage } from '@supabase/supabase-js'
 import { browserEnv, isAuthToken } from '../utils.js'
 import { base } from '$app/paths'
 
@@ -19,9 +19,13 @@ const setCsrf = () => {
 const cookie_route = `${base}/supakit/cookie`
 const csrf_route = `${base}/supakit/csrf`
 
-export const CookieStorage: SupportedStorage = {
-  async getItem(key) {
-    if (!browserEnv()) return null
+export class CookieStorage {
+  constructor(
+		private readonly session: Session | null
+	) {}
+
+  async getItem(key: string) {
+    if (!browserEnv()) return this.session
     if (isAuthToken(key) && cached_session) return cached_session
     let csrf = getCsrf()
 
@@ -71,8 +75,8 @@ export const CookieStorage: SupportedStorage = {
         throw err
       }
     }
-  },
-  async setItem(key, value) {
+  }
+  async setItem(key: string, value: string) {
     if (!browserEnv()) return
     if (isAuthToken(key)) cached_session = JSON.parse(value)
     const csrf = getCsrf()
@@ -90,8 +94,8 @@ export const CookieStorage: SupportedStorage = {
       console.error('Error setting cookie', err)
       return
     }
-  },
-  async removeItem(key) {
+  }
+  async removeItem(key: string) {
     if (!browserEnv()) return
     if (isAuthToken(key)) cached_session = null
     const csrf = getCsrf()

--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -59,7 +59,8 @@ export function createSupabaseLoadClient<
     : any
 >(
   supabase_url: string, 
-  supabase_key: string, 
+  supabase_key: string,
+  session: Session | null,
   options?: SupabaseClientOptionsWithLimitedAuth, 
   cookie_options?: SecureCookieOptionsPlusName
 ): SupabaseClient<Database, SchemaName, Schema>


### PR DESCRIPTION
- breaking: fix client storage

This is a breaking patch. It requires that the server `session` be passed into `createSupabaseLoadClient()` as the 3rd argument.
This fixes an issue where the `supabase` client is unauthenticated; causing calls to the db to not return data, even though a user is logged in.